### PR TITLE
Update GitHub actions to remove deprecation warnings

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,6 +17,7 @@ jobs:
         java-version: 8
         java-package: jdk
 
+    - name: Build
       run: |
         mkdir target
         timestamp=$(date -u +%Y%m%d-%H%M%S)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,8 @@ on: [push]
 jobs:
   build:
 
+    runs-on: ubuntu-latest
+
     steps:
     - uses: actions/checkout@v3
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,17 +5,15 @@ on: [push]
 jobs:
   build:
 
-    runs-on: ubuntu-latest
-
     steps:
-    - uses: actions/checkout@v2
-    
-    - name: Set up JDK 1.8
-      uses: actions/setup-java@v1
-      with:
-        java-version: 1.8
+    - uses: actions/checkout@v3
 
-    - name: Build
+    - name: Set up JDK 1.8
+      uses: actions/setup-java@v3
+      with:
+        distribution: 'zulu'
+        java-version: 8
+        java-package: jdk
 
       run: |
         mkdir target
@@ -23,7 +21,7 @@ jobs:
         echo "TIMESTAMP=${timestamp}" >>$GITHUB_ENV
         bash prepareBPCartefacts-github.sh target github ${timestamp}z DELETE-REPOSITORY-FILES-AS-WELL
 
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v3
       with:
         name: bpc-semantics-github-${{ env.TIMESTAMP }}z
         path: ./*


### PR DESCRIPTION
Old V2 invocations are replaced with V3 invocations.